### PR TITLE
add .gitignore and ensure empty workspace folder exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+workspace

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,5 +32,5 @@ Vagrant.configure(2) do |config|
     cd /opt/ && sudo tar -zxvf eclipse-committers-oxygen-3-linux-gtk-x86_64.tar.gz
   SHELL
 
-  config.vm.synced_folder "workspace/", "/home/vagrant/workspace/"
+  config.vm.synced_folder "workspace/", "/home/vagrant/workspace/", create: true
 end

--- a/workspace/.gitignore
+++ b/workspace/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/workspace/.gitignore
+++ b/workspace/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
The vagrant config assumes that the folder "workspace" exists.
Currently, if the repo is freshly cloned the workspace folder doesn't exist and starting the VM fails.